### PR TITLE
Message in AWS has changed causing the regex on delete to break

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ Stack.prototype.delete = function(cb) {
   console.log('Deleting stack ' + self.stackName + '...');
   cf.deleteStack({StackName: self.stackName}, function(err, data) {
     self.waitUntilEnd(function(err, succeeded) {
-      if(/Stack:.*does not exist/.test(err) || /Stack not up/.test(err)) {
+      if(/Stack:?.*does not exist/.test(err) || /Stack not up/.test(err)) {
         console.log('Delete complete');
         return cb(null, true);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudformer-node",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A port of the Ruby AWS CloudFormation tooling https://github.com/kunday/cloudformer",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This is the new message

{ [ValidationError: Stack with id travelin-web-application-image-65 does not exist]
  message: 'Stack with id travelin-web-application-image-65 does not exist',
  code: 'ValidationError',
  time: Mon Jun 29 2015 13:24:27 GMT+1000 (AEST),
  statusCode: 400,
  retryable: false,
  retryDelay: 30 }
